### PR TITLE
Update constants to work with newer KOReader versions

### DIFF
--- a/autorotate.koplugin/main.lua
+++ b/autorotate.koplugin/main.lua
@@ -9,6 +9,7 @@ local Screen = Device.screen
 local Event = require("ui/event")
 local UIManager = require("ui/uimanager")
 local _ = require("gettext")
+local logger = require("logger")
 
 local AutoRotate = WidgetContainer:new{
     name = "AutoRotate",
@@ -16,11 +17,16 @@ local AutoRotate = WidgetContainer:new{
 
 function AutoRotate:onPageUpdate(page)
   local page_size = self.ui.document:getNativePageDimensions(page)
-  -- rot = Device.screen:getRotationMode()
-  if (page_size.w > page_size.h) then
-    UIManager:broadcastEvent(Event:new("SetRotationMode", Screen.ORIENTATION_LANDSCAPE))
+  rotation = Screen:getRotationMode()
+
+  if (page_size.w > page_size.h and rotation ~= Screen.DEVICE_ROTATED_CLOCKWISE) then
+    logger.dbg("[AutoRotate] Rotating clockwise")
+    UIManager:broadcastEvent(Event:new("SetRotationMode", Screen.DEVICE_ROTATED_CLOCKWISE))
+  elseif (page_size.h > page_size.w and rotation ~= Screen.DEVICE_ROTATED_UPRIGHT) then
+    logger.dbg("[AutoRotate] Rotating upright")
+    UIManager:broadcastEvent(Event:new("SetRotationMode", Screen.DEVICE_ROTATED_UPRIGHT))
   else
-    UIManager:broadcastEvent(Event:new("SetRotationMode", Screen.ORIENTATION_PORTRAIT))
+    -- logger.dbg("[AutoRotate] Not doing anything")
   end
 end
 


### PR DESCRIPTION
* Update the constants (e.g. `Screen.ORIENTATION_LANDSCAPE` to `Screen.DEVICE_ROTATED_CLOCKWISE`) to allow this plugin to work with newer versions.
* Check rotation first and do nothing if already in the correct rotation
* Add some logging

Tested on my PineNote.