### PR TITLE
Return to either portrait orientation after exiting landscape

### DIFF
--- a/autorotate.koplugin/main.lua
+++ b/autorotate.koplugin/main.lua
@@ -15,16 +15,23 @@ local AutoRotate = WidgetContainer:new{
     name = "AutoRotate",
 }
 
+last_portrait = Screen.DEVICE_ROTATED_UPRIGHT
+
 function AutoRotate:onPageUpdate(page)
   local page_size = self.ui.document:getNativePageDimensions(page)
   rotation = Screen:getRotationMode()
+  
+  if (rotation == Screen.DEVICE_ROTATED_UPRIGHT or rotation == Screen.DEVICE_ROTATED_UPSIDE_DOWN) then
+	last_portrait = rotation
+	logger.dbg("[AutoRotate] Rotating updating last portrait rotation")
+  end
 
   if (page_size.w > page_size.h and rotation ~= Screen.DEVICE_ROTATED_CLOCKWISE) then
     logger.dbg("[AutoRotate] Rotating clockwise")
     UIManager:broadcastEvent(Event:new("SetRotationMode", Screen.DEVICE_ROTATED_CLOCKWISE))
-  elseif (page_size.h > page_size.w and rotation ~= Screen.DEVICE_ROTATED_UPRIGHT) then
+  elseif (page_size.h > page_size.w and (rotation ~= Screen.DEVICE_ROTATED_UPRIGHT or rotation ~= Screen.DEVICE_ROTATED_UPSIDE_DOWN)) then
     logger.dbg("[AutoRotate] Rotating upright")
-    UIManager:broadcastEvent(Event:new("SetRotationMode", Screen.DEVICE_ROTATED_UPRIGHT))
+    UIManager:broadcastEvent(Event:new("SetRotationMode", last_portrait))
   else
     -- logger.dbg("[AutoRotate] Not doing anything")
   end

--- a/autorotate.koplugin/main.lua
+++ b/autorotate.koplugin/main.lua
@@ -26,9 +26,13 @@ function AutoRotate:onPageUpdate(page)
 	logger.dbg("[AutoRotate] Rotating updating last portrait rotation")
   end
 
-  if (page_size.w > page_size.h and rotation ~= Screen.DEVICE_ROTATED_CLOCKWISE) then
+  if (page_size.w > page_size.h and (rotation ~= Screen.DEVICE_ROTATED_CLOCKWISE or rotation ~= Screen.DEVICE_ROTATED_COUNTER_CLOCKWISE)) then
     logger.dbg("[AutoRotate] Rotating clockwise")
-    UIManager:broadcastEvent(Event:new("SetRotationMode", Screen.DEVICE_ROTATED_CLOCKWISE))
+	if (last_portrait == Screen.DEVICE_ROTATED_UPRIGHT) then
+          UIManager:broadcastEvent(Event:new("SetRotationMode", Screen.DEVICE_ROTATED_CLOCKWISE))
+	else
+	  UIManager:broadcastEvent(Event:new("SetRotationMode", Screen.DEVICE_ROTATED_COUNTER_CLOCKWISE))
+	end
   elseif (page_size.h > page_size.w and (rotation ~= Screen.DEVICE_ROTATED_UPRIGHT or rotation ~= Screen.DEVICE_ROTATED_UPSIDE_DOWN)) then
     logger.dbg("[AutoRotate] Rotating upright")
     UIManager:broadcastEvent(Event:new("SetRotationMode", last_portrait))


### PR DESCRIPTION
Notably this does not add support for choosing a landscape mode based on the portrait mode that enters it, as this is not conducive to button layouts on devices with physical keys.